### PR TITLE
fix(packaging): remove Modules paths from install file after modular split

### DIFF
--- a/debian/abraflexi-digest.install
+++ b/debian/abraflexi-digest.install
@@ -5,12 +5,8 @@ debian/autoload.php 		usr/share/php/abraflexi-digest/
 src/*.php		        usr/share/abraflexi-digest/
 web/*.php		        usr/share/abraflexi-digest/
 src/Digest/*                    usr/lib/abraflexi-digest/Digest/
-src/Digest/Modules/*		usr/lib/abraflexi-digest/Digest/Modules/
 src/Digest/Outlook/*		usr/lib/abraflexi-digest/Digest/Outlook/
-src/Digest/Modules/AllTime/*    usr/lib/abraflexi-digest/Digest/Modules/AllTime/
-#empty yet src/Digest/Modules/Daily/*	    usr/lib/abraflexi-digest/Digest/Modules/Daily/
-src/Digest/Modules/Weekly/*    usr/lib/abraflexi-digest/Digest/Modules/Weekly/
-src/Digest/Modules/Monthly/*    usr/lib/abraflexi-digest/Digest/Modules/Monthly/
+src/Digest/Providers/*          usr/lib/abraflexi-digest/Digest/Providers/
 src/css/*.css                   usr/share/abraflexi-digest/css/
 src/css/themes/*.css            usr/share/abraflexi-digest/css/themes
 bin/*                           usr/bin/


### PR DESCRIPTION
## Summary

- Remove stale `src/Digest/Modules/*`, `AllTime/*`, `Weekly/*`, `Monthly/*` entries from `debian/abraflexi-digest.install` — these directories no longer exist in this repo since they were split into the separate `php-vitexsoftware-digest-modules` package
- Add `src/Digest/Providers/*` to cover the new `AbraFlexiDataProvider.php`
- `php-vitexsoftware-digest-modules` and `php-vitexsoftware-digest-renderer` already have their own packaging; `control` already lists them as `Depends`

## Test plan

- [ ] Jenkins build of `abraflexi-digest` completes without `dh_install: missing files` error
- [ ] Resulting `.deb` contains `usr/lib/abraflexi-digest/Digest/Providers/AbraFlexiDataProvider.php`
- [ ] Package installs cleanly alongside `php-vitexsoftware-digest-modules` and `php-vitexsoftware-digest-renderer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package installation configuration to include Outlook and Providers digest components.
  * Removed legacy module installation mappings from the package deployment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VitexSoftware/AbraFlexi-Digest/pull/48)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->